### PR TITLE
chore: upgrade the image version to v1.0.1

### DIFF
--- a/permify.go
+++ b/permify.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	defaultPermifyImage        = "ghcr.io/permify/permify"
-	defaultPermifyImageVersion = "v0.10.2"
+	defaultPermifyImageVersion = "v1.0.1"
 	permifyRestPort            = "3476/tcp"
 	permifyGrpcPort            = "3478/tcp"
 	permifyStartupCommand      = "serve"


### PR DESCRIPTION
With the release of v1.0 for Permify, need to update to the latest image tag.